### PR TITLE
Fix CMake custom command warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,5 @@ set(destination "${CMAKE_CURRENT_BINARY_DIR}/resources")
 add_custom_command(
     TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E create_symlink ${source} ${destination} 
-    DEPENDS ${destination}
     COMMENT "symbolic link resources folder from ${source} => ${destination}"
 )


### PR DESCRIPTION
This PR fixes a CMake warning caused by the following section:
```cmake
add_custom_command(
    TARGET ${PROJECT_NAME} POST_BUILD
    COMMAND ${CMAKE_COMMAND} -E create_symlink ${source} ${destination} 
    DEPENDS ${destination}                                                      # <-- This line right here
    COMMENT "symbolic link resources folder from ${source} => ${destination}"
)
```